### PR TITLE
Updating from node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
   delta_bytes: # size of changed data
     description: The overall number of bytes changed in the output data this run (current size - previous size)
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   post: 'dist/post/index.js'
 branding:


### PR DESCRIPTION
I'm getting a warning that the action needs to be updated to node16 as node12 is no longer supported by Github.

<img width="1155" alt="Screenshot 2023-03-26 at 15 47 34" src="https://user-images.githubusercontent.com/863286/227755860-dedc946b-c8bd-4c07-8d32-318f44782739.png">
